### PR TITLE
Fix inner class not detecting annotations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "com.ruben"
-version = "0.3.0"
+version = "0.3.2"
 
 repositories {
     mavenCentral()
@@ -52,17 +52,20 @@ tasks {
     }
 
     patchPluginXml {
-        sinceBuild.set("193.*")
+        sinceBuild.set("201.*")
     }
 }
 
 tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml") {
     changeNotes.set(
-        """<br><b>Initial Release v0.2.3:</b></br>
-        Inspect kotlin data classes for missing <b>SerializedName</b> annotations
+        """<br><b>v0.3.2: </b></br>
+        Fix inner class not detecting required annotation
         <br></br>
-        <br><b>v0.3.0: </b></br>
-        Added support for <b>Json (Moshi)</b> and <b>SerialName (Kotlinx-Serialization)</b> annotations.
+        <br><b>v0.3.1: </b></br>
+        Added support for <b>Json (Moshi)</b> and <b>SerialName (Kotlinx-Serialization)</b> annotations
+        <br></br>
+        <br><b>Initial Release v0.2.3:</b></br>
+        Inspect kotlin data classes for missing <b>SerializedName</b> annotations
         """
     )
 }

--- a/src/main/kotlin/com/ruben/codespector/DataClassAnnotationInspector.kt
+++ b/src/main/kotlin/com/ruben/codespector/DataClassAnnotationInspector.kt
@@ -28,17 +28,7 @@ class DataClassAnnotationInspector: AbstractKotlinInspection() {
         return classVisitor { ktClass ->
             if (ktClass.isData()) {
                 //check if annotation is required
-                val paramList: List<KtParameter> = when (parser) {
-                     Parser.GSON -> {
-                         ktClass.getMissingSerializedNameAnnotationParams()
-                     }
-                    Parser.MOSHI -> {
-                        ktClass.getMissingJsonAnnotationParams()
-                    }
-                    else -> {
-                        ktClass.getMissingSerialNameParams()
-                    }
-                }
+                val paramList: List<KtParameter> = getMissingAnnotations(parser = parser, ktClass = ktClass)
                 paramList.forEach {
                     holder.registerProblem(
                         it as PsiElement,

--- a/src/main/kotlin/com/ruben/codespector/DataClassAnnotationNotification.kt
+++ b/src/main/kotlin/com/ruben/codespector/DataClassAnnotationNotification.kt
@@ -49,17 +49,7 @@ class DataClassAnnotationNotification: EditorNotifications.Provider<EditorNotifi
                 (psiClass as? KtLightClassForSourceDeclaration)?.let { ktLightClassForSourceDeclaration ->
                     val ktClass = ktLightClassForSourceDeclaration.kotlinOrigin as? KtClass
                     if (ktClass?.isData() == true) {
-                        val paramList = when (parser) {
-                            Parser.GSON -> {
-                                ktClass.getMissingSerializedNameAnnotationParams()
-                            }
-                            Parser.MOSHI -> {
-                                ktClass.getMissingJsonAnnotationParams()
-                            }
-                            else -> {
-                                ktClass.getMissingSerialNameParams()
-                            }
-                        }
+                        val paramList = getMissingAnnotations(parser = parser, ktClass = ktClass)
                         if (paramList.isNotEmpty()) {
                             removeNotification(fileEditor)
                             return createPanel(
@@ -81,7 +71,7 @@ class DataClassAnnotationNotification: EditorNotifications.Provider<EditorNotifi
                     (innerClass as? KtLightClassForSourceDeclaration)?.let { ktLightClassForSourceDeclaration ->
                         val ktClass = ktLightClassForSourceDeclaration.kotlinOrigin as? KtClass
                         if (ktClass?.isData() == true) {
-                            val paramList = ktClass.getMissingSerializedNameAnnotationParams()
+                            val paramList = getMissingAnnotations(parser = parser, ktClass = ktClass)
                             if (paramList.isNotEmpty()) {
                                 removeNotification(fileEditor)
                                 return createPanel(

--- a/src/main/kotlin/com/ruben/codespector/Utility.kt
+++ b/src/main/kotlin/com/ruben/codespector/Utility.kt
@@ -1,0 +1,22 @@
+package com.ruben.codespector
+
+import com.ruben.codespector.settings.Parser
+import org.jetbrains.kotlin.psi.KtClass
+import org.jetbrains.kotlin.psi.KtParameter
+
+/**
+ * Created by Ruben Quadros on 20/11/22
+ **/
+fun getMissingAnnotations(parser: Parser, ktClass: KtClass): List<KtParameter> {
+    return when (parser) {
+        Parser.GSON -> {
+            ktClass.getMissingSerializedNameAnnotationParams()
+        }
+        Parser.MOSHI -> {
+            ktClass.getMissingJsonAnnotationParams()
+        }
+        else -> {
+            ktClass.getMissingSerialNameParams()
+        }
+    }
+}


### PR DESCRIPTION
Fix:
* Inner class was only detecting missing `SerializedName` annotation
* Detect missing `Json` and `SerialName` annotations as well